### PR TITLE
Added TypeModel extension method to allow custom type models

### DIFF
--- a/src/NServiceBus.ProtoBuf/Definition.cs
+++ b/src/NServiceBus.ProtoBuf/Definition.cs
@@ -10,14 +10,16 @@ namespace NServiceBus.ProtoBuf;
 public class ProtoBufSerializer :
     SerializationDefinition
 {
+    public static string ContentEncoding { get; } = "protobuf";
+
     /// <summary>
     /// <see cref="SerializationDefinition.Configure"/>
     /// </summary>
     public override Func<IMessageMapper, IMessageSerializer> Configure(IReadOnlySettings settings) =>
         _ =>
         {
-            var runtimeTypeModel = settings.GetRuntimeTypeModel();
-            var contentTypeKey = settings.GetContentTypeKey();
+            var runtimeTypeModel = settings.GetTypeModel();
+            var contentTypeKey = settings.GetContentTypeKey() ?? ContentEncoding;
             return new MessageSerializer(contentTypeKey, runtimeTypeModel);
         };
 }

--- a/src/NServiceBus.ProtoBuf/MessageSerializer.cs
+++ b/src/NServiceBus.ProtoBuf/MessageSerializer.cs
@@ -4,27 +4,12 @@ using ProtoBuf.Meta;
 class MessageSerializer :
     IMessageSerializer
 {
-    RuntimeTypeModel runtimeTypeModel;
+    readonly TypeModel TypeModel;
 
-    public MessageSerializer(string? contentType, RuntimeTypeModel? runtimeTypeModel)
+    public MessageSerializer(string contentType, TypeModel? typeModel)
     {
-        if (runtimeTypeModel == null)
-        {
-            this.runtimeTypeModel = RuntimeTypeModel.Default;
-        }
-        else
-        {
-            this.runtimeTypeModel = runtimeTypeModel;
-        }
-
-        if (contentType == null)
-        {
-            ContentType = "protobuf";
-        }
-        else
-        {
-            ContentType = contentType;
-        }
+        TypeModel = typeModel ?? RuntimeTypeModel.Default;
+        ContentType = contentType;
     }
 
     public void Serialize(object message, Stream stream)
@@ -34,13 +19,13 @@ class MessageSerializer :
         {
             throw new("Interface based message are not supported. Create a class that implements the desired interface.");
         }
-        runtimeTypeModel.Serialize(stream, message);
+        TypeModel.Serialize(stream, message);
     }
 
     public object[] Deserialize(ReadOnlyMemory<byte> body, IList<Type> messageTypes)
     {
         var messageType = messageTypes.First();
-        var message = runtimeTypeModel.Deserialize(body, type: messageType);
+        var message = TypeModel.Deserialize(body, type: messageType);
         return new[] { message };
     }
 

--- a/src/NServiceBus.ProtoBuf/ProtoBufConfigurationExtensions.cs
+++ b/src/NServiceBus.ProtoBuf/ProtoBufConfigurationExtensions.cs
@@ -28,7 +28,7 @@ public static class ProtoBufConfigurationExtensions
     /// Configures string to use for <see cref="Headers.ContentType"/> headers.
     /// </summary>
     /// <remarks>
-    /// Defaults to "wire".
+    /// Defaults to "protobuf".
     /// </remarks>
     /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
     /// <param name="contentTypeKey">The content type key to use.</param>

--- a/src/NServiceBus.ProtoBuf/ProtoBufConfigurationExtensions.cs
+++ b/src/NServiceBus.ProtoBuf/ProtoBufConfigurationExtensions.cs
@@ -15,14 +15,25 @@ public static class ProtoBufConfigurationExtensions
     /// </summary>
     /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
     /// <param name="runtimeTypeModel">The <see cref="RuntimeTypeModel"/> to use.</param>
+    [Obsolete("Please use TypeModel property")]
     public static void RuntimeTypeModel(this SerializationExtensions<ProtoBufSerializer> config, RuntimeTypeModel runtimeTypeModel)
     {
         var settings = config.GetSettings();
-        settings.Set(runtimeTypeModel);
+        settings.Set((TypeModel)runtimeTypeModel);
+    }
+    /// <summary>
+    /// Configures the <see cref="TypeModel"/> to use.
+    /// </summary>
+    /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
+    /// <param name="typeModel">The <see cref="RuntimeTypeModel"/> to use.</param>
+    public static void TypeModel(this SerializationExtensions<ProtoBufSerializer> config, TypeModel typeModel)
+    {
+        var settings = config.GetSettings();
+        settings.Set(typeModel);
     }
 
-    internal static RuntimeTypeModel GetRuntimeTypeModel(this IReadOnlySettings settings) =>
-        settings.GetOrDefault<RuntimeTypeModel>();
+    internal static TypeModel GetTypeModel(this IReadOnlySettings settings) =>
+        settings.GetOrDefault<TypeModel>();
 
     /// <summary>
     /// Configures string to use for <see cref="Headers.ContentType"/> headers.

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -1,11 +1,17 @@
 using NServiceBus.ProtoBuf;
+using ProtoBuf.Meta;
 
 class Program
 {
     static async Task Main()
     {
+        var model = RuntimeTypeModel.Create();
+        model.Add<MyMessage>();
+
         var configuration = new EndpointConfiguration("ProtoBufSerializerSample");
-        configuration.UseSerialization<ProtoBufSerializer>();
+        var serializer = configuration.UseSerialization<ProtoBufSerializer>();
+        serializer.TypeModel(model.Compile());
+        serializer.ContentTypeKey("application/x-protobuf; protobuf-net");
         configuration.UseTransport<LearningTransport>();
         configuration.UsePersistence<LearningPersistence>();
 


### PR DESCRIPTION
Now possible to provide a TypeModel instead of the specific `RuntimeTypeModel`. Obsoleted the `RuntimeTypeModel` extension method with guidance to migrate to the `TypeModel` property.

Updated the sample that shows how to use a pre-compiled type model using the new `TypeModel` option.